### PR TITLE
configured logging timestamps 

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,8 +1,18 @@
-import logging
+def main():
+    import logging
 
-from pydiscogs import botbuilder
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)-4s %(name)-25s %(message)s",
+        level=logging.INFO,
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 
-bot = botbuilder.build_bot("egroup-bot.yaml")
+    from pydiscogs import botbuilder
 
-logging.info("running bot: %s", bot)
-bot.run(bot.discord_token)
+    bot = botbuilder.build_bot("egroup-bot.yaml")
+    logging.info("running bot: %s", bot)
+    bot.run(bot.discord_token)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
ensured importing logging and defing format before other imports which would overwrite logging config if imported first