### PR TITLE
fix(deps): update pydiscogs (768 dims) & bump to v0.2.4

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "app"
-version = "0.2.3"
+version = "0.2.4"
 description = "Add your description here"
 readme = "README.md"
 requires-python = "==3.13.11"

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -495,7 +495,7 @@ pydantic-core==2.41.4
     # via pydantic
 pydantic-settings==2.12.0
     # via mcp
-pydiscogs @ git+https://github.com/bpafoshizle/pydiscogs@690351bdaf7f411eece81a0299ba32ec6b5e12a6
+pydiscogs @ git+https://github.com/bpafoshizle/pydiscogs@b2954ae4cc7656bc4dc112031e07245d559e6972
     # via app (app/pyproject.toml)
 pyjwt==2.10.1
     # via mcp


### PR DESCRIPTION
Updates pydiscogs to use a wrapper enforcing 768 dimensions for gemini-embedding-001 (to avoid HNSW 2000 limit) and bumps app version to 0.2.4.